### PR TITLE
Version 1.2.0

### DIFF
--- a/FloodOnlineReportingTool.Contracts/EligibilityCheckCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/EligibilityCheckCreated.cs
@@ -14,5 +14,6 @@ public record EligibilityCheckCreated(
     int ImpactDurationHours,
     bool IsOnGoing,
     bool IsUninhabitable,
-    int? VulnerableCount
+    int? VulnerableCount,
+    IReadOnlyCollection<EligibilityCheckOrganisation> Organisations
 );

--- a/FloodOnlineReportingTool.Contracts/EligibilityCheckCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/EligibilityCheckCreated.cs
@@ -7,7 +7,7 @@ public record EligibilityCheckCreated(
     Guid Id,
     string FloodReportReference,
     DateTimeOffset CreatedUtc,
-    long Uprn,
+    long? Uprn,
     double Easting,
     double Northing,
     DateTimeOffset? ImpactStartUTC,

--- a/FloodOnlineReportingTool.Contracts/EligibilityCheckOrganisation.cs
+++ b/FloodOnlineReportingTool.Contracts/EligibilityCheckOrganisation.cs
@@ -1,0 +1,8 @@
+﻿namespace FloodOnlineReportingTool.Contracts;
+
+public record EligibilityCheckOrganisation(
+    Guid Id,
+    string Name, // Not required, but useful for display
+    Guid FloodAuthorityId,
+    string FloodAuthorityName // Not required, but useful for display
+);

--- a/FloodOnlineReportingTool.Contracts/EligibilityCheckUpdated.cs
+++ b/FloodOnlineReportingTool.Contracts/EligibilityCheckUpdated.cs
@@ -6,12 +6,13 @@
 public record EligibilityCheckUpdated(
     Guid Id,
     DateTimeOffset UpdatedUtc,
-    long Uprn,
+    long? Uprn,
     double Easting,
     double Northing,
     DateTimeOffset? ImpactStartUTC,
     int ImpactDurationHours,
     bool IsOnGoing,
     bool IsUninhabitable,
-    int? VulnerableCount
+    int? VulnerableCount,
+    IReadOnlyCollection<EligibilityCheckOrganisation> Organisations
 );

--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.1.1</Version>
+		<Version>1.2.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/Shared/FloodAuthorityIds.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/FloodAuthorityIds.cs
@@ -1,0 +1,16 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared;
+
+/// <summary>
+/// The flood authority Id's.
+/// Helps ensure consistency and allows easier comparison.
+/// </summary>
+public static class FloodAuthorityIds
+{
+    public readonly static Guid EnvironmentAgency = new("018fd118-9400-76d5-a61a-9ff695c06588");
+    public readonly static Guid LeadLocalFloodAuthority = new("018fd119-7e60-7384-bb2b-c157b8b576c6");
+    public readonly static Guid WaterAuthority = new("018fd11a-68c0-7c64-8412-495da1eeb0ba");
+    public readonly static Guid GasBoard = new("018fd11b-5320-7f24-a39d-b76cc8bffc8b");
+    public readonly static Guid ElectricityBoard = new("018fd11c-3d80-7348-b528-d2cd55312a98");
+    public readonly static Guid CATRespond = new("018fd11d-27e0-76bc-9176-177880b52135");
+    public readonly static Guid Voluntary = new("018fd11e-1240-782f-8aa3-f7a3fea26810");
+}

--- a/FloodOnlineReportingTool.Contracts/Shared/FloodAuthorityIds.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/FloodAuthorityIds.cs
@@ -1,7 +1,7 @@
 ﻿namespace FloodOnlineReportingTool.Contracts.Shared;
 
 /// <summary>
-/// The flood authority Id's.
+/// The flood authority IDs.
 /// Helps ensure consistency and allows easier comparison.
 /// </summary>
 public static class FloodAuthorityIds

--- a/FloodOnlineReportingTool.Contracts/Shared/OrganisationIds.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/OrganisationIds.cs
@@ -1,7 +1,7 @@
 ﻿namespace FloodOnlineReportingTool.Contracts.Shared;
 
 /// <summary>
-/// The organisation Id's.
+/// The organisation IDs.
 /// Helps ensure consistency and allows easier comparison.
 /// </summary>
 public static class OrganisationIds

--- a/FloodOnlineReportingTool.Contracts/Shared/OrganisationIds.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/OrganisationIds.cs
@@ -1,0 +1,12 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared;
+
+/// <summary>
+/// The organisation Id's.
+/// Helps ensure consistency and allows easier comparison.
+/// </summary>
+public static class OrganisationIds
+{
+    public readonly static Guid Dorset = new("018fe5b2-0400-7281-b27e-87ba8cbbec3a");
+    public readonly static Guid Wessex = new("018fe5b2-ee60-7347-aa68-16b8f528dab0");
+    public readonly static Guid DevonCornwall = new("018fe5b3-d8c0-7bc1-95fa-7dcc50ee866d");
+}


### PR DESCRIPTION
- Version 1.2.0
- New basic organisation data added to EligibilityCheckCreated and EligibilityCheckUpdated contracts
- Changed Uprn to be optional in EligibilityCheckCreated and EligibilityCheckUpdated contracts
- New shared OrganisationIds static class (examples Dorset, Wessex)
- New shared FloodAuthorityIds static class (examples EnvironmentAgency, LeadLocalFloodAuthority)