### PR TITLE
Add comment types to shared project

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/Shared/CommentType.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/CommentType.cs
@@ -1,0 +1,18 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared;
+
+public enum CommentType
+{
+    /// <summary>
+    /// All the comment types available for the FORT system.
+    /// </summary>
+    PublicComment = 0,
+    UserComment,
+    ProblemComment,
+    ImpactComment,
+    DescriptionComment,
+    HistoryComment,
+    CauseComment,
+    SourceDetails,
+    AssistanceComment,
+    AdminComment
+}

--- a/FloodOnlineReportingTool.Contracts/Shared/CommentType.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/CommentType.cs
@@ -1,10 +1,10 @@
 ﻿namespace FloodOnlineReportingTool.Contracts.Shared;
 
+/// <summary>
+/// All the comment types available for the FORT system.
+/// </summary>
 public enum CommentType
 {
-    /// <summary>
-    /// All the comment types available for the FORT system.
-    /// </summary>
     PublicComment = 0,
     UserComment,
     ProblemComment,


### PR DESCRIPTION
This PR adds a new category of comment type to the shared context. 

The purpose of this enum is to allow the various versions of FORT to know which comment types are known to all systems and allow communication to be passed between the systems when comments are created, read and replied to. 