### PR TITLE
Task topic names

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>3.1.0</Version>
+		<Version>3.2.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodReportUpdated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportUpdated.cs
@@ -2,7 +2,7 @@
 
 /// <summary>
 /// This message is used to communicate changes to the flood records between systems. 
-/// It updating the record status and may optionally also be triggering an action requests.
+/// Updating the record status and may optionally also be triggering an action requests.
 /// </summary>
 public record FloodReportUpdated
 (

--- a/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
+++ b/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
@@ -7,9 +7,8 @@ public static class TopicNames
     public const string EligibilityCheckCreated = "flood-eligibility-check-created";
     public const string EligibilityCheckUpdated = "flood-eligibility-check-updated";
     public const string FloodReportCreated = "flood-report-created";
-    public const string FloodReportUpdated = "flood-report-updated";
     public const string FloodReportDeleted = "flood-report-deleted";
-    public const string FloodReportStatusUpdated = "flood-report-status-updated";
+    public const string FloodReportUpdated = "flood-report-updated";
     public const string InvestigationCreated = "flood-investigation-created";
     public const string PasswordResetCodeSent = "flood-password-reset-code-sent";
     public const string PasswordResetLinkSent = "flood-password-reset-link-sent";

--- a/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
+++ b/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
@@ -1,0 +1,16 @@
+﻿
+namespace FloodOnlineReportingTool.Contracts.Topics;
+
+public static class TopicNames
+{
+    public const string ConfirmationLinkSent = "flood-confirmation-link-sent";
+    public const string EligibilityCheckCreated = "flood-eligibility-check-created";
+    public const string EligibilityCheckUpdated = "flood-eligibility-check-updated";
+    public const string FloodReportCreated = "flood-report-created";
+    public const string FloodReportUpdated = "flood-report-updated";
+    public const string FloodReportDeleted = "flood-report-deleted";
+    public const string FloodReportStatusUpdated = "flood-report-status-updated";
+    public const string InvestigationCreated = "flood-investigation-created";
+    public const string PasswordResetCodeSent = "flood-password-reset-code-sent";
+    public const string PasswordResetLinkSent = "flood-password-reset-link-sent";
+}


### PR DESCRIPTION
- define all topic names
- simpler names to work well with Azure service bus library and MassTransit
- version 3.2.0

notes:

file FloodReportStatusUpdate renamed to FloodReportUpdated to match the name of the class. The class was not renamed.

for MassTransit to use these set names changes like this will be needed
```csharp
config.Message<EligibilityCheckCreated>(m => m.SetEntityName(TopicNames.EligibilityCheckCreated));
```