### PR TITLE
Version 5.0.0 - Add flood report reference to search results

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>4.0.0</Version>
+		<Version>4.1.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>4.1.0</Version>
+		<Version>5.0.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/Shared/Search/SearchResultFloodReport.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/Search/SearchResultFloodReport.cs
@@ -1,10 +1,9 @@
 ﻿namespace FloodOnlineReportingTool.Contracts.Shared.Search;
 
 /// <summary>
-/// Represents a search result for a flood report, including its unique identifier, creation and update timestamps,
-/// data sources.
+/// Represents a flood report search result, including its reference, status, and associated source records.
 /// </summary>
-/// <param name="RecordStatusId">Is a GUID representing a RecordStatusIds</param>
+/// <param name="RecordStatusId">The unique identifier of the record status.</param>
 public record SearchResultFloodReport(
    Guid Id,
    string Reference,

--- a/FloodOnlineReportingTool.Contracts/Shared/Search/SearchResultFloodReport.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/Search/SearchResultFloodReport.cs
@@ -7,6 +7,7 @@
 /// <param name="RecordStatusId">Is a GUID representing a RecordStatusIds</param>
 public record SearchResultFloodReport(
    Guid Id,
+   string Reference,
    Guid RecordStatusId,
    IReadOnlyCollection<SearchResultFloodReportSource> SourceRecords
 );


### PR DESCRIPTION
We are adding a user friendly reference to the flood reports for display in search results. 

This new property needs adding to the search result record definition for use by the other modules. 

Version 5.0.0