### PR TITLE
Add geometry (coordinates) to the flood report messages.

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.0.0-beta</Version>
+		<Version>6.0.1-beta</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodReportCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportCreated.cs
@@ -12,6 +12,8 @@ public record FloodReportCreated(
     Guid Id,
     string Reference,
     DateTimeOffset CreatedUtc,
+    double Easting,
+    double Northing,
     bool HasContacts,
     IReadOnlyCollection<ContactRecordType> ContactRecordTypes
 );

--- a/FloodOnlineReportingTool.Contracts/FloodReportCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportCreated.cs
@@ -6,7 +6,7 @@ namespace FloodOnlineReportingTool.Contracts;
 /// Flood report created contract using an immutable record.
 /// 
 /// This is used to notify flood risk management modules that a new flood report has been created ready for review.
-/// We only provide the reference required to search within the module and whether or not there are contacts.  
+/// We only provide the reference / location required to search within the module and whether or not there are contacts.  
 /// </summary>
 public record FloodReportCreated(
     Guid Id,

--- a/FloodOnlineReportingTool.Contracts/FloodReportUpdated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportUpdated.cs
@@ -13,6 +13,8 @@ public record FloodReportUpdated(
     string Reference,
     DateTimeOffset UpdatedUtc,
     Guid RecordStatusId, // Updated flood report RecordStatusId
+    double Easting,
+    double Northing,
     bool HasInvestigation,
     bool HasContacts,
     IReadOnlyCollection<ContactRecordType> ContactRecordTypes


### PR DESCRIPTION
This PR adds the coordinates to flood report messages as these are needed to allow filtering messages and actions by user range.
The coordinates are already in the `EligibilityCheckRecord` for flood report source rows hence using the same method to transfer the data between the systems. 
Flood Reports are point records so the geometry will always be describable with a single set of coordinates. 

Version number is 6.0.1-beta as this is a pre-release so ignoring the normal rules about whether this is a minor or major change. All pre-release changes we make here will eventually be the version 6 full release. 