### PR TITLE
Update action log shared settings

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.0.3-beta</Version>
+		<Version>6.0.4-beta</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.0.2-beta</Version>
+		<Version>6.0.3-beta</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.0.4-beta</Version>
+		<Version>6.0.3-beta</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/Shared/ActionTypeIds.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/ActionTypeIds.cs
@@ -3,29 +3,35 @@
 namespace FloodOnlineReportingTool.Contracts.Shared;
 public static class ActionTypeIds
 {
-    /// <summary>
-    /// These actions are requests to another system to request a person performs an action.
-    /// </summary>
-    public readonly static Guid RequestInvestiagtion = new("a1b2c3d4-5e6f-4789-8abc-1234567890ab");
-    public readonly static Guid RequestReply = new("b2c3d4e5-6f70-489a-9bcd-2345678901bc");
-    public readonly static Guid RequestDataProtectionReview = new("c3d4e5f6-7081-49ab-acde-3456789012cd");
+    public readonly static Guid TriggerFloodSourceArchive = new("076a4d83-4572-48b2-ae67-185c0877693f");
+    public readonly static Guid TriggerFloodSourceRestore = new("febe4f8e-ca64-4e83-aabb-99bb15ae25ab");
+    public readonly static Guid TriggerFloodSourceRedaction = new("8067409e-7883-4fa9-a7cd-2ccd82ef4074");
+    public readonly static Guid TriggerFloodSourceDelete = new("c2d3c27a-a0f6-46f0-b036-9a68b22e55f2");
 
-    /// <summary>
-    /// These actions are requests to another system to perform an action.
-    /// </summary>
+    public readonly static Guid TriggerFloodReportArchive = new("1a572d25-4dcb-464e-b4d4-b93a74d618aa");
+    public readonly static Guid TriggerFloodReportRestore = new("3f9f56fe-0ca5-4851-90ec-8f7a3082c95c");
+    public readonly static Guid TriggerFloodReportRedaction = new("ccdcd417-1283-4545-988f-0fc7584bbda0");
+    public readonly static Guid TriggerFloodReportDelete = new("7afdfe7c-04a0-43d5-bf9b-abe53e1f2b1c");
+
+    public readonly static Guid TriggerEventArchive = new("e5f6a7b8-92a3-4bcd-cdef-5678901234ef");
+    public readonly static Guid TriggerEventRestore = new("d3510bd2-5141-4bcc-8f00-847cf8f9ef19");
+    public readonly static Guid TriggerEventDelete = new("123caad9-c1b9-4149-8f9e-3ef33dcd037b");
+
+    public readonly static Guid FurtherDetailRequested = new("a1b2c3d4-5e6f-4789-8abc-1234567890ab");
+    public readonly static Guid FurtherDetailProvided = new("df655f85-fef9-4388-ab22-f10fd491657d");
+
     public readonly static Guid TriggerSection19 = new("d4e5f6a7-8192-4abc-bdef-4567890123de");
-    public readonly static Guid TriggerRecordLock = new("e5f6a7b8-92a3-4bcd-cdef-5678901234ef");
-    public readonly static Guid TriggerReplyReceived = new("f6a7b8c9-a3b4-4cde-def0-6789012345f0");
+    public readonly static Guid TriggerSection19Complete = new("e310c7f5-2c0e-447f-aa27-6cb4c6aea033");
 
-    /// <summary>
-    /// These actions are used to communicate the result of an action taken between the systems using a shared Guid.
-    /// </summary>
-    public readonly static Guid NotificationSent = new("a7b8c9d0-b4c5-4def-ef01-789012345601");
-    public readonly static Guid NotificationError = new("b8c9d0e1-c5d6-4ef0-f012-890123456712");
+    public readonly static Guid CommentNew = new("24b82488-37ed-4c36-8aae-82479611c3b5");
+    public readonly static Guid CommentReply = new("f6a7b8c9-a3b4-4cde-def0-6789012345f0");
 
     public readonly static ImmutableHashSet<Guid> All = [
-        RequestInvestiagtion, RequestReply, RequestDataProtectionReview,
-        TriggerSection19, TriggerRecordLock, TriggerReplyReceived,
-        NotificationSent, NotificationError,
+        TriggerFloodSourceArchive, TriggerFloodSourceRestore, TriggerFloodSourceRedaction, TriggerFloodSourceDelete,
+        TriggerFloodReportArchive, TriggerFloodReportRestore, TriggerFloodReportRedaction, TriggerFloodReportDelete,
+        TriggerEventArchive, TriggerEventRestore, TriggerEventDelete,
+        FurtherDetailRequested, FurtherDetailProvided,
+        TriggerSection19, TriggerSection19Complete,
+        CommentNew, CommentReply,
     ];
 }

--- a/FloodOnlineReportingTool.Contracts/Shared/Models/FloodReportWithSourceReferences.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/Models/FloodReportWithSourceReferences.cs
@@ -1,0 +1,16 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared.Models;
+
+public record FloodReportWithSourceReferences
+{
+    public required Guid Id { get; init; }
+    public required string Reference { get; init; }
+    public required Guid RecordStatus { get; init; }
+    public required FloodReportType RecordType { get; init; }
+    public DateTimeOffset CreatedUtc { get; init; }
+    public DateTimeOffset? UpdatedUtc { get; init; }
+    public double Easting { get; init; }
+    public double Northing { get; init; }
+    public decimal Latitude { get; init; }
+    public decimal Longitude { get; init; }
+    public IReadOnlyCollection<string> SourceReferences { get; init; } = [];
+}

--- a/FloodOnlineReportingTool.Contracts/Shared/ReportTypes.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/ReportTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared;
+
+public enum FloodReportType
+{
+    Property,
+    Road,
+    Location,
+}


### PR DESCRIPTION
The main updates include new action type GUIDs, the addition of a new data model for flood reports with source references, and a new enumeration for flood report types. Additionally, the package version has been incremented.

**Action Type Updates:**

- Expanded the `ActionTypeIds` class with new GUIDs for flood source, flood report, and event actions (archive, restore, redaction, delete), as well as new actions for further detail requests and comments. Cleaned up old/unused action types and updated the `All` set accordingly.

**New Models and Types:**

- Added a new record, `FloodReportWithSourceReferences`, which includes details about a flood report and its related source references.
- Introduced a new enum, `FloodReportType`, to classify flood reports as `Property`, `Road`, or `Location`.
(note, is this logic now outdated? Do we want to remove the property/road/location logic at some point?)
Not required for this PR though.  

**Versioning:**

- Updated the project version in `FloodOnlineReportingTool.Contracts.csproj` from `6.0.2-beta` to `6.0.4-beta`.