### PR TITLE
Add SearchFloodReportPagedResult record

### DIFF
--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.0.3-beta</Version>
+		<Version>6.1.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/Shared/Search/SearchFloodReportPagedResult.cs
+++ b/FloodOnlineReportingTool.Contracts/Shared/Search/SearchFloodReportPagedResult.cs
@@ -1,0 +1,15 @@
+﻿namespace FloodOnlineReportingTool.Contracts.Shared.Search;
+
+/// <summary>
+/// Represents a paginated result set specifically for Flood Reports, including the collection of results, 
+/// a count of the total flood source records, and metadata about the pagination state.
+/// </summary>
+/// <remarks>This record is similar to PagedResult, but tweaked to include the total flood source count.</remarks>
+public record SearchFloodReportPagedResult<T>(
+    IReadOnlyCollection<T> Results,
+    int TotalCount,
+    int TotalFloodSourceCount,
+    int PageSize,
+    int CurrentPage,
+    int TotalPages
+) : PagedResult<T>(Results, TotalCount, PageSize, CurrentPage, TotalPages);


### PR DESCRIPTION
This PR created a `SearchFloodReportPagedResult` record which inherits from `PagedResult` and adds the Flood Report specific `TotalFloodSourceCount` property.

This will allow this issue - https://github.com/Dorset-Council-UK/FloodOnlineReportingTool.RiskManagement/issues/133 - To be fixed.