### PR TITLE
Update build.yml to reduce permissions required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
     
 permissions:
   contents: read
-  id-token: write  # enable GitHub OIDC token issuance for this job
   
 jobs:
   build:
@@ -37,6 +36,8 @@ jobs:
     needs: build
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+        id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:
       - uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-        id-token: write  # enable GitHub OIDC token issuance for this job
+      contents: read
+      id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:
       - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
This PR move the id-token permission from the global level to the specific publish job, reducing unnecessary permission scope.