### PR TITLE
Update contract naming and add flood source contract

### DIFF
--- a/FloodOnlineReportingTool.Contracts/ActionRequest.cs
+++ b/FloodOnlineReportingTool.Contracts/ActionRequest.cs
@@ -1,0 +1,16 @@
+using FloodOnlineReportingTool.Contracts.Shared;
+
+namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// This record allows us to bind together an action with associated information (if required).
+/// </summary>
+/// <remarks>Use <see cref="FloodEventActionRequest"/> instead.</remarks>
+[Obsolete($"Use {nameof(FloodEventActionRequest)} instead.", error: false)]
+public record ActionRequest
+(
+    Guid ActionRequestId,
+    IReadOnlyCollection<ContactRecordType> ContactRecordTypes,
+    string? ActionRequestMessageId,
+    string? ActionRequestMessage
+);

--- a/FloodOnlineReportingTool.Contracts/ConfirmationLinkSent.cs
+++ b/FloodOnlineReportingTool.Contracts/ConfirmationLinkSent.cs
@@ -3,6 +3,6 @@
 /// <summary>
 /// Contract used to re-trigger email validation for a given contact record using an immutable record.
 /// </summary>
-/// <remarks>Use <see cref="VerifyContactTriggered"/> instead.</remarks>
-[Obsolete($"Use {nameof(VerifyContactTriggered)} instead.", error: false)]
+/// <remarks>Use <see cref="FloodReportSourceVerifyContact"/> instead.</remarks>
+[Obsolete($"Use {nameof(FloodReportSourceVerifyContact)} instead.", error: false)]
 public record ConfirmationLinkSent(string ContactRecordId);

--- a/FloodOnlineReportingTool.Contracts/FloodEventActionRequest.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodEventActionRequest.cs
@@ -24,7 +24,7 @@ namespace FloodOnlineReportingTool.Contracts;
 /// <param name="ActionRequestMessage">
 /// Optional - if you are requesting a reply you may want to include a message to be sent.
 /// </param>
-public record ActionRequest
+public record FloodEventActionRequest
 (
     Guid ActionRequestId,
     IReadOnlyCollection<ContactRecordType> ContactRecordTypes,

--- a/FloodOnlineReportingTool.Contracts/FloodEventCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodEventCreated.cs
@@ -1,0 +1,16 @@
+﻿namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Flood event created contract using an immutable record.
+/// 
+/// This is used to notify flood risk management modules that a new flood event has been created ready for review.
+/// We only provide the reference / location required to search within the module and whether or not there are linked flood reports.  
+/// </summary>
+public record FloodEventCreated(
+    Guid Id,
+    string Reference,
+    string Title,
+    DateTimeOffset CreatedUtc,
+    bool HasSection19Report,
+    IReadOnlyCollection<Guid> LinkedFloodReports
+);

--- a/FloodOnlineReportingTool.Contracts/FloodEventS19Completed.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodEventS19Completed.cs
@@ -1,9 +1,9 @@
 ﻿namespace FloodOnlineReportingTool.Contracts;
 
 /// <summary>
-/// Contact record created contract using an immutable record.
+/// TODO : This contract doesn't seem to be what it should be. This should be a message to indicate that a flood event section 19 report has been completed, but it contains a lot of properties that are not relevant to the flood event itself.
 /// </summary>
-public record InvestigationCreated
+public record FloodEventS19Completed
 {
     public required string FloodReportReference { get; init; }
     public required Guid Id { get; init; }

--- a/FloodOnlineReportingTool.Contracts/FloodEventS19Triggered.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodEventS19Triggered.cs
@@ -3,4 +3,4 @@
 /// <summary>
 /// Investigation triggered contract using an immutable record.
 /// </summary>
-public record InvestigationTriggered(Guid Id, string Reference, DateTimeOffset TriggeredUtc);
+public record FloodEventS19Triggered(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/FloodEventUpdated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodEventUpdated.cs
@@ -1,0 +1,14 @@
+﻿namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Flood event updated contract using an immutable record.
+/// 
+/// This is used to notify flood risk management modules that a flood event has been updated.
+/// </summary>
+public record FloodEventUpdated(
+    Guid Id,
+    string Title,
+    DateTimeOffset UpdatedUtc,
+    bool HasSection19Report,
+    IReadOnlyCollection<Guid> LinkedFloodReports
+);

--- a/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
+++ b/FloodOnlineReportingTool.Contracts/FloodOnlineReportingTool.Contracts.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>6.1.0</Version>
+		<Version>6.2.0</Version>
 		<Authors>Dorset Council</Authors>
 		<Company>Dorset Council</Company>
 		<Description>Contains the contracts used for the messaging system of the Flood Online Reporting Tool.</Description>

--- a/FloodOnlineReportingTool.Contracts/FloodReportExtraInfoRequest.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportExtraInfoRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Flood Report contract to trigger request for extra info using an immutable record.
+/// </summary>
+public record FloodReportExtraInfoRequest(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/FloodReportSourceUpdated.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportSourceUpdated.cs
@@ -14,5 +14,5 @@ public record FloodReportSourceUpdated
     DateTimeOffset UpdatedUtc,
     Guid RecordStatusUpdate,
     EligibilityCheckRecord? EligibilityCheckRecord,
-    IReadOnlyCollection<ActionRequest> ActionStatusUpdates
+    IReadOnlyCollection<FloodEventActionRequest> ActionStatusUpdates
 );

--- a/FloodOnlineReportingTool.Contracts/FloodReportSourceVerifyContact.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportSourceVerifyContact.cs
@@ -3,4 +3,4 @@
 /// <summary>
 /// Contract used to re-trigger email validation for a given contact record using an immutable record.
 /// </summary>
-public record VerifyContactTriggered(string ContactRecordId);
+public record FloodReportSourceVerifyContact(string ContactRecordId);

--- a/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
@@ -1,6 +1,0 @@
-﻿namespace FloodOnlineReportingTool.Contracts;
-
-/// <summary>
-/// Flood Report trigger contract using an immutable record.
-/// </summary>
-public record FloodReportTriggerExtra(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
@@ -1,6 +1,6 @@
 ﻿namespace FloodOnlineReportingTool.Contracts;
 
 /// <summary>
-/// Flood Report Source Investigation triggered contract using an immutable record.
+/// Flood Report trigger contract using an immutable record.
 /// </summary>
 public record FloodReportTriggerExtra(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
+++ b/FloodOnlineReportingTool.Contracts/FloodReportTriggerExtra.cs
@@ -1,0 +1,6 @@
+﻿namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Flood Report Source Investigation triggered contract using an immutable record.
+/// </summary>
+public record FloodReportTriggerExtra(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/InvestigationCreated.cs
+++ b/FloodOnlineReportingTool.Contracts/InvestigationCreated.cs
@@ -1,0 +1,28 @@
+namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Contract indicating that a flood event section 19 report has been completed.
+/// </summary>
+/// <remarks>Use <see cref="FloodEventS19Completed"/> instead.</remarks>
+[Obsolete($"Use {nameof(FloodEventS19Completed)} instead.", error: false)]
+public record InvestigationCreated
+{
+    public required string FloodReportReference { get; init; }
+    public required Guid Id { get; init; }
+    public required DateTimeOffset CreatedUtc { get; init; }
+    public required bool HasEntries { get; init; }
+    public required bool HasHistory { get; init; }
+    public required bool HasPropertyInsurance { get; init; }
+    public required bool HasPeakDepth { get; init; }
+    public required bool HasInternalFlooding { get; init; }
+    public required bool HasDestination { get; init; }
+    public required bool HasDamagedVehicles { get; init; }
+    public required bool HasImpactedServices { get; init; }
+    public required bool HasImpactedTheCommunity { get; init; }
+    public required bool HasBlockages { get; init; }
+    public required bool ActionsWereTaken { get; init; }
+    public required bool HelpWasReceived { get; init; }
+    public required bool RegisteredWithFloodline { get; init; }
+    public bool ReceivedFloodlineWarningInTime { get; init; }
+    public required bool ReceivedOtherWarnings { get; init; }
+}

--- a/FloodOnlineReportingTool.Contracts/InvestigationTriggered.cs
+++ b/FloodOnlineReportingTool.Contracts/InvestigationTriggered.cs
@@ -1,0 +1,8 @@
+namespace FloodOnlineReportingTool.Contracts;
+
+/// <summary>
+/// Investigation triggered contract using an immutable record.
+/// </summary>
+/// <remarks>Use <see cref="FloodEventS19Triggered"/> instead.</remarks>
+[Obsolete($"Use {nameof(FloodEventS19Triggered)} instead.", error: false)]
+public record InvestigationTriggered(Guid Id, string Reference, DateTimeOffset TriggeredUtc);

--- a/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
+++ b/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
@@ -3,14 +3,20 @@ namespace FloodOnlineReportingTool.Contracts.Topics;
 
 public static class TopicNames
 {
-    public const string ActionRequest = "floodreport-action-request";
+    // Flood Report contracts
     public const string FloodReportCreated = "floodreport-created";
     public const string FloodReportUpdated = "floodreport-updated";
     public const string FloodReportDeleted = "floodreport-deleted";
+    public const string FloodReportTriggerExtra = "floodreport-trigger-extra";
+
+    // Flood Report Source contracts
     public const string FloodReportSourceCreated = "floodreport-source-created";
     public const string FloodReportSourceUpdated = "floodreport-source-updated";
     public const string FloodReportSourceDeleted = "floodreport-source-deleted";
-    public const string InvestigationCreated = "floodreport-investigation-created";
-    public const string InvestigationTriggered = "floodreport-investigation-triggered";
-    public const string VerifyContactTriggered = "floodreport-verify-contact-triggered";
+    public const string FloodReportSourceVerifyContact = "floodreport-source-verify-contact";
+
+    // Flood Event contracts
+    public const string FloodEventActionRequest = "floodevent-action-request";
+    public const string FloodEventS19Completed = "floodevent-s19-completed";
+    public const string FloodEventS19Triggered = "floodevent-s19-triggered";
 }

--- a/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
+++ b/FloodOnlineReportingTool.Contracts/Topics/TopicNames.cs
@@ -7,7 +7,7 @@ public static class TopicNames
     public const string FloodReportCreated = "floodreport-created";
     public const string FloodReportUpdated = "floodreport-updated";
     public const string FloodReportDeleted = "floodreport-deleted";
-    public const string FloodReportTriggerExtra = "floodreport-trigger-extra";
+    public const string FloodReportExtraInfoRequest = "floodreport-extra-info-request";
 
     // Flood Report Source contracts
     public const string FloodReportSourceCreated = "floodreport-source-created";
@@ -16,6 +16,8 @@ public static class TopicNames
     public const string FloodReportSourceVerifyContact = "floodreport-source-verify-contact";
 
     // Flood Event contracts
+    public const string FloodEventCreated = "floodevent-created";
+    public const string FloodEventUpdated = "floodevent-updated";
     public const string FloodEventActionRequest = "floodevent-action-request";
     public const string FloodEventS19Completed = "floodevent-s19-completed";
     public const string FloodEventS19Triggered = "floodevent-s19-triggered";


### PR DESCRIPTION
Add FloodReportTriggerExtra as InvestigationTriggered needs to trigger for flood events not flood reports.
I decided to update the contracts to make it clearer where the function is primarily flood event (risk managment), flood report (report status) or flood report source (public). This has resulted in some renaming of contracts.
Investigation changed to S19 to keep topic names shorter.

Version 6.2.0 due to alpha development phase. We are not moving to version 7 until the application progresses to beta.